### PR TITLE
planner: count only OF-named tables in the SKIP LOCKED guard

### DIFF
--- a/pkg/executor/batch_point_get_test.go
+++ b/pkg/executor/batch_point_get_test.go
@@ -327,3 +327,129 @@ func TestSelectForUpdateSkipLocked(t *testing.T) {
 	tk1.MustExec("commit")
 	tk2.MustExec("commit")
 }
+
+func TestSelectForUpdateSkipLockedWithOfClause(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	tk1.MustExec("set session tidb_enable_select_skip_locked = 1")
+	tk2.MustExec("set session tidb_enable_select_skip_locked = 1")
+
+	tk1.MustExec("drop view if exists ofc_view")
+	tk1.MustExec("drop table if exists ofc_ti, ofc_job, ofc_run, ofc_part")
+	tk1.MustExec("create table ofc_ti (id int primary key, job_id int, run_id int)")
+	tk1.MustExec("create table ofc_job (id int primary key)")
+	tk1.MustExec("create table ofc_run (id int primary key)")
+	tk1.MustExec("insert into ofc_job values (1)")
+	tk1.MustExec("insert into ofc_run values (1)")
+	tk1.MustExec("insert into ofc_ti values (1, 1, 1), (2, 1, 1), (3, 1, 1)")
+
+	const claim = "select ofc_ti.id from ofc_ti " +
+		"join ofc_job on ofc_job.id = ofc_ti.job_id " +
+		"join ofc_run on ofc_run.id = ofc_ti.run_id " +
+		"order by ofc_ti.id for update of ofc_ti skip locked"
+
+	// A join locking one table is served: rows locked by the other transaction are
+	// skipped, and the tables not named in OF stay unlocked.
+	tk1.MustExec("begin pessimistic")
+	tk2.MustExec("begin pessimistic")
+	tk1.MustQuery("select id from ofc_ti where id = 2 for update").Check(testkit.Rows("2"))
+	tk2.MustQuery(claim).Check(testkit.Rows("1", "3"))
+	// Probed from tk1, so the claim's own locks cannot satisfy them.
+	tk1.MustQuery("select id from ofc_job where id = 1 for update nowait").Check(testkit.Rows("1"))
+	tk1.MustQuery("select id from ofc_run where id = 1 for update nowait").Check(testkit.Rows("1"))
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+
+	// The rows the claim did not skip are really locked.
+	tk1.MustExec("begin pessimistic")
+	tk2.MustExec("begin pessimistic")
+	tk1.MustQuery(claim).Check(testkit.Rows("1", "2", "3"))
+	tk2.MustContainErrMsg("select id from ofc_ti where id = 1 for update nowait", "3572")
+	tk2.MustQuery(claim).Check(testkit.Rows())
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+
+	// An alias in OF refers to the aliased occurrence, as MySQL allows.
+	tk1.MustExec("begin pessimistic")
+	tk1.MustQuery("select t.id from ofc_ti t join ofc_job on ofc_job.id = t.job_id " +
+		"order by t.id for update of t skip locked").Check(testkit.Rows("1", "2", "3"))
+	tk1.MustExec("commit")
+
+	// A plain FOR UPDATE OF locks only the named table, as it did before the guard
+	// learned to read the OF list.
+	tk1.MustExec("begin pessimistic")
+	tk2.MustExec("begin pessimistic")
+	tk1.MustQuery("select ofc_ti.id from ofc_ti join ofc_job on ofc_job.id = ofc_ti.job_id " +
+		"order by ofc_ti.id for update of ofc_ti").Check(testkit.Rows("1", "2", "3"))
+	tk2.MustQuery("select id from ofc_job where id = 1 for update nowait").Check(testkit.Rows("1"))
+	tk2.MustContainErrMsg("select id from ofc_ti where id = 1 for update nowait", "3572")
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+
+	// On a prepared-plan-cache hit buildSelect does not re-run, so filterLockTableKeys
+	// narrows nothing and only the plan carries the OF list. The second execution must
+	// still leave the unnamed table alone.
+	tk1.MustExec("prepare claim_of from 'select ofc_ti.id from ofc_ti " +
+		"join ofc_job on ofc_job.id = ofc_ti.job_id order by ofc_ti.id for update of ofc_ti'")
+	tk1.MustExec("begin pessimistic")
+	tk1.MustQuery("execute claim_of").Check(testkit.Rows("1", "2", "3"))
+	tk1.MustExec("commit")
+	tk1.MustExec("begin pessimistic")
+	tk1.MustQuery("execute claim_of").Check(testkit.Rows("1", "2", "3"))
+	tk1.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk2.MustExec("begin pessimistic")
+	tk2.MustQuery("select id from ofc_job where id = 1 for update nowait").Check(testkit.Rows("1"))
+	tk2.MustContainErrMsg("select id from ofc_ti where id = 1 for update nowait", "3572")
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+
+	// Locking more than one table still needs per-output-row lock groups.
+	tk1.MustContainErrMsg("select ofc_ti.id from ofc_ti join ofc_job on ofc_job.id = ofc_ti.job_id "+
+		"for update skip locked", "SKIP LOCKED on multi-table SELECT FOR UPDATE")
+	tk1.MustContainErrMsg("select ofc_ti.id from ofc_ti join ofc_job on ofc_job.id = ofc_ti.job_id "+
+		"for update of ofc_ti, ofc_job skip locked", "SKIP LOCKED on multi-table SELECT FOR UPDATE")
+
+	// A subquery's OF clause says nothing about what the outer clause locks, in either
+	// direction: it must not excuse an outer statement that names no table, nor reject
+	// an outer statement that names one.
+	tk1.MustContainErrMsg("select ofc_ti.id from ofc_ti join ofc_job on ofc_job.id = ofc_ti.job_id "+
+		"where ofc_ti.id in (select j.id from ofc_job j for update of j) "+
+		"for update skip locked", "SKIP LOCKED on multi-table SELECT FOR UPDATE")
+	tk1.MustExec("begin pessimistic")
+	tk1.MustQuery("select ofc_ti.id from ofc_ti join ofc_job on ofc_job.id = ofc_ti.job_id " +
+		"where ofc_ti.id in (select j.id from ofc_job j for update of j) " +
+		"order by ofc_ti.id for update of ofc_ti skip locked").Check(testkit.Rows("1"))
+	tk1.MustExec("commit")
+
+	// A name that resolves to nothing is still rejected by the locking clause itself.
+	tk1.MustContainErrMsg("select ofc_ti.id from ofc_ti join ofc_job on ofc_job.id = ofc_ti.job_id "+
+		"for update of nosuch skip locked", "nosuch")
+
+	// A view resolves to a table ID the plan tracks no handle for, so narrowing would
+	// empty the map and the count would fall to zero. The join stays rejected.
+	tk1.MustExec("create view ofc_view as select id, job_id, run_id from ofc_ti")
+	tk1.MustContainErrMsg("select ofc_view.id from ofc_view "+
+		"join ofc_job on ofc_job.id = ofc_view.job_id "+
+		"join ofc_run on ofc_run.id = ofc_view.run_id "+
+		"for update of ofc_view skip locked", "SKIP LOCKED on multi-table SELECT FOR UPDATE")
+
+	// A partitioned table named in OF is rejected: narrowing the count would accept a
+	// statement whose keys carry partition IDs the OF list cannot match, locking nothing.
+	tk1.MustExec("create table ofc_part (id int primary key, job_id int) " +
+		"partition by range (id) (partition p0 values less than (10), " +
+		"partition p1 values less than (100))")
+	tk1.MustExec("insert into ofc_part values (1, 1), (50, 1)")
+	tk1.MustContainErrMsg("select ofc_part.id from ofc_part join ofc_job on ofc_job.id = ofc_part.job_id "+
+		"for update of ofc_part skip locked", "SKIP LOCKED on a partitioned table")
+	// Without OF there is nothing to narrow, so the single-table form still locks.
+	tk1.MustExec("begin pessimistic")
+	tk1.MustQuery("select id from ofc_part order by id for update skip locked").Check(testkit.Rows("1", "50"))
+	tk2.MustExec("begin pessimistic")
+	tk2.MustContainErrMsg("select id from ofc_part where id = 1 for update nowait", "3572")
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1610,6 +1610,25 @@ func removeGlobalIndexPaths(paths []*util.AccessPath) []*util.AccessPath {
 
 func (b *PlanBuilder) buildSelectLock(src base.LogicalPlan, lock *ast.SelectLockInfo) (*logicalop.LogicalLock, error) {
 	tblID2Handle := b.handleHelper.tailMap()
+	if len(lock.Tables) != 0 {
+		lockedTbls := b.lockedTables(lock.Tables)
+		if ids := lockedTableIDs(lockedTbls); len(ids) != 0 {
+			if lock.LockType == ast.SelectLockForUpdateSkipLocked && anyPartitioned(lockedTbls) {
+				// filterLockTableKeys tests a row key's physical partition ID against the
+				// logical table IDs resolved from OF, so it drops every key of a partitioned
+				// table and no lock is taken. Reject rather than narrow the count into
+				// accepting a statement that would silently lock nothing.
+				return nil, dbterror.ErrNotSupportedYet.GenWithStackByArgs("SKIP LOCKED on a partitioned table named in FOR UPDATE OF")
+			}
+			// Only narrow when the OF list names a table the plan tracks a handle for. A
+			// view or memory table resolves to an ID that never appears in tblID2Handle,
+			// so narrowing would empty the map: the count would drop to zero, the guard
+			// would accept, and LogicalLock would lock nothing.
+			if filtered := filterLockedTables(ids, tblID2Handle); len(filtered) != 0 {
+				tblID2Handle = filtered
+			}
+		}
+	}
 	if lock.LockType == ast.SelectLockForUpdateSkipLocked {
 		// v1 of SKIP LOCKED supports locking a single table occurrence only: a skipped
 		// base row of a join would have to remove derived rows whose other side is
@@ -1642,6 +1661,52 @@ func (b *PlanBuilder) buildSelectLock(src base.LogicalPlan, lock *ast.SelectLock
 	}.Init(b.ctx)
 	selectLock.SetChildren(src)
 	return selectLock, nil
+}
+
+// lockedTables resolves the tables named in this statement's `FOR UPDATE OF t [, t2]` clause. It
+// resolves the clause's own list rather than reading StmtCtx.LockTableIDs, which is a union across
+// every query block in the statement: a subquery's OF clause would otherwise decide what the outer
+// clause is judged to lock. Names preprocess could not resolve are skipped, as buildSelect does.
+func (b *PlanBuilder) lockedTables(tables []*ast.TableName) []*model.TableInfo {
+	infos := make([]*model.TableInfo, 0, len(tables))
+	for _, tName := range tables {
+		tNameW := b.resolveCtx.GetTableName(tName)
+		if tNameW == nil || tNameW.TableInfo == nil {
+			continue
+		}
+		infos = append(infos, tNameW.TableInfo)
+	}
+	return infos
+}
+
+func lockedTableIDs(tables []*model.TableInfo) map[int64]struct{} {
+	ids := make(map[int64]struct{}, len(tables))
+	for _, tbl := range tables {
+		ids[tbl.ID] = struct{}{}
+	}
+	return ids
+}
+
+func anyPartitioned(tables []*model.TableInfo) bool {
+	for _, tbl := range tables {
+		if tbl.GetPartitionInfo() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// filterLockedTables narrows tblID2Handle to the tables the lock clause names, so callers that count
+// locked tables see what will actually be locked. filterLockTableKeys applies the same narrowing to
+// the keys when the lock is taken.
+func filterLockedTables(lockTableIDs map[int64]struct{}, tblID2Handle map[int64][]util.HandleCols) map[int64][]util.HandleCols {
+	filtered := make(map[int64][]util.HandleCols, len(lockTableIDs))
+	for tblID, cols := range tblID2Handle {
+		if _, ok := lockTableIDs[tblID]; ok {
+			filtered[tblID] = cols
+		}
+	}
+	return filtered
 }
 
 func setExtraPhysTblIDColsOnDataSource(p base.LogicalPlan, tblID2PhysTblIDCol map[int64]*expression.Column) {


### PR DESCRIPTION
Thanks for building this. I've been running your branch to get Apache Airflow onto TiDB and hit one shape the v1 guard rejects that I think it can serve.

Airflow's scheduler claims tasks with a join that locks a single table:

```sql
SELECT ti.* FROM task_instance ti
  JOIN dag_run dr ON ...
  JOIN dag_model dm ON ...
FOR UPDATE OF ti SKIP LOCKED
```

`tblID2Handle` holds one handle per joined table, so the count is 3 and this is rejected, though only `ti` is locked. Job-queue claiming is the main use for SKIP LOCKED and this is its usual shape.

`filterLockTableKeys` already drops keys outside the `OF` list, so locking is right and only the count is wrong. This narrows the handle map to the named tables before counting.

Narrowing can turn your loud error into a silent lost lock. Three cases, each guarded:

- IDs resolve from the clause's own `OF` list via `resolveCtx`. `StmtCtx.LockTableIDs` is a union across query blocks, so a subquery's `OF` would decide what the outer clause is judged to lock.
- A partitioned table in `OF` stays rejected: `filterLockTableKeys` tests a row key's physical partition ID against the logical one, dropping every key.
- An empty intersection doesn't narrow. A view resolves to an ID absent from `tblID2Handle`, emptying the map and zeroing the count.

Happy to reshape or drop this if the v1 scope is deliberate.

## Testing

Two sessions, Airflow's query shape:

```
$ python af_claim.py     # planner change reverted
pymysql.err.NotSupportedError: (1235, "This version of TiDB doesn't yet support
'SKIP LOCKED on multi-table SELECT FOR UPDATE'")

$ python af_claim.py     # this branch
scheduler B claimed: [1, 3] (row 2 held by A)
A=[1, 2, 3]  B=[]  OVERLAP=[]
```

Row 2 is skipped, not waited on, and two claimers never take the same row.

Shapes that must stay rejected — pre-fix, an intermediate that read the union, and this branch:

```
                                            pre-fix   union-read       this branch
A no-OF 2-table join, SKIP LOCKED           ERR 1235  ERR 1235         ERR 1235
B subquery OF jb + outer no-OF SKIP LOCKED  ERR 1235  OK, locks none   ERR 1235
C join OF <partitioned> SKIP LOCKED         ERR 1235  OK, locks none   ERR 1235
D 3-table view, OF v SKIP LOCKED            ERR 1235  OK, locks none   ERR 1235
E airflow shape, OF ti SKIP LOCKED          ERR 1235  OK rows=3        OK rows=3
```

`FOR UPDATE OF` without SKIP LOCKED is unchanged, which is what makes narrowing safe:

```
=== pre-fix ===                     === this branch ===
no OF  -> par=LOCKED  ch=LOCKED     no OF  -> par=LOCKED  ch=LOCKED
OF ch  -> par=free    ch=LOCKED     OF ch  -> par=free    ch=LOCKED
```

`TestSelectForUpdateSkipLockedWithOfClause` covers the above plus alias resolution and the plan-cache path. It sits beside your mockstore coverage in `batch_point_get_test.go` — `tests/realtikvtest/` forces a real TiKV connection in `RunTestMain`.

```
$ go test -tags=intest ./pkg/executor/ -run TestSelectForUpdateSkipLocked
--- PASS: TestSelectForUpdateSkipLocked (0.54s)
--- PASS: TestSelectForUpdateSkipLockedWithOfClause (0.49s)
ok      github.com/pingcap/tidb/pkg/executor    2.629s

$ go test -tags=intest ./pkg/planner/core/ -run 'TestSelectLockSkipLocked|TestPointGetWithSelectLock'
--- PASS: TestPointGetWithSelectLock (0.41s)
--- PASS: TestSelectLockSkipLocked (0.38s)
ok      github.com/pingcap/tidb/pkg/planner/core 2.659s
```

## Note on the branch

`feature/skip-locked` doesn't compile against the `kvproto` its own `go.mod` pins:

```
pkg/store/mockstore/unistore/tikv/mvcc.go:265:9: req.SkipLocked undefined
    (type *kvrpcpb.PessimisticLockRequest has no field or method SkipLocked)
pkg/store/mockstore/unistore/tikv/mvcc.go:351:24: undefined:
    kvrpcpb.PessimisticLockKeyResultType_LockResultSkipped
```

I built and tested with `replace` directives onto forks of both carrying the skip-locked proto, and left them out of this PR since they're my pins. The `require` lines likely want updating so the branch builds standalone.
